### PR TITLE
Update the book name：绿宝书->绿宝书| JavaScript语言精髓与编程实践（第3版）

### DIFF
--- a/docs/fe/javascript.md
+++ b/docs/fe/javascript.md
@@ -123,7 +123,7 @@
 * [小黄书| 你不知道的javascript 上](https://book.douban.com/subject/26351021/)
 * [小黄书| 你不知道的javascript 中](https://book.douban.com/subject/26854244/)
 * [Javasript二十年](https://book.douban.com/subject/35446937/)
-* [绿宝书](https://book.douban.com/subject/35085910/)
+* [绿宝书| JavaScript语言精髓与编程实践（第3版）](https://book.douban.com/subject/35085910/)
 * [前端开发核心知识进阶](https://book.douban.com/subject/35218831/)
 
 ## 付费教程


### PR DESCRIPTION
根据此部分上面的格式，这里应该补全绿宝书的书名：JavaScript语言精髓与编程实践（第3版）